### PR TITLE
docs: update README with project root navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This boilerplate uses the following tools::
 git clone https://github.com/irabbi360/nuxt3-starter.git
 ```
 
+Navigate to the project's root directory:
+
+```bash
+cd nuxt3-starter
+```
+
 Make sure to install the dependencies:
 
 ```bash


### PR DESCRIPTION
### Summary  
This PR updates the README file by adding instructions to navigate to the project's root directory before installing dependencies.

### Changes  
- Added a step to navigate to the project root (`cd nuxt3-starter`) before running `npm install`.  

### Why?  
These updates improve the clarity of the setup process.

Thanks for your amazing project.